### PR TITLE
Fixed installation of test apk's

### DIFF
--- a/screengrab/lib/screengrab/runner.rb
+++ b/screengrab/lib/screengrab/runner.rb
@@ -178,13 +178,13 @@ module Screengrab
 
     def install_apks(device_serial, app_apk_path, tests_apk_path)
       UI.message('Installing app APK')
-      apk_install_output = run_adb_command("adb -s #{device_serial} install -r #{app_apk_path.shellescape}",
+      apk_install_output = run_adb_command("adb -s #{device_serial} install -t -r #{app_apk_path.shellescape}",
                                            print_all: true,
                                            print_command: true)
       UI.user_error!("App APK could not be installed") if apk_install_output.include?("Failure [")
 
       UI.message('Installing tests APK')
-      apk_install_output = run_adb_command("adb -s #{device_serial} install -r #{tests_apk_path.shellescape}",
+      apk_install_output = run_adb_command("adb -s #{device_serial} install -t -r #{tests_apk_path.shellescape}",
                                            print_all: true,
                                            print_command: true)
       UI.user_error!("Tests APK could not be installed") if apk_install_output.include?("Failure [")


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
This pull request fixes #11722 in the context of Screengrab.
Since Android Gradle Plugin/Android Studio 3.0 the test APKs contain a manifest entry `android:testOnly="true"`. This leads to an error when Screengrab tries to install the APK onto the emulator, because it does not allow to install testOnly apps by default. Since the APK controlling the screenshot capturing is also a test APK we currently need to rely on the workaround pointed out in #11722.

### Description
The fix is to add the `-t` flag to the `adb install` command, which allows to also install testOnly APKs. This is also how Android Studio installs the apk to the device.

Excerpt of adb help:
```
$ adb --help
Android Debug Bridge version 1.0.40
Version 4797878
...
app installation:
 install [-lrtsdg] [--instant] PACKAGE
 install-multiple [-lrtsdpg] [--instant] PACKAGE...
     push package(s) to the device and install them
     -l: forward lock application
     -r: replace existing application
     -t: allow test packages
     -s: install application on sdcard
     -d: allow version code downgrade (debuggable packages only)
     -p: partial application install (install-multiple only)
     -g: grant all runtime permissions
     --instant: cause the app to be installed as an ephemeral install app
...
```